### PR TITLE
Bump Firezone base to OTP 25.2.1 and Elixir 1.14.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   ERLANG_MAJOR: "25"
-  ERLANG: "25.1.2"
+  ERLANG: "25.2.1"
   OS_VERSION: "3.16.3"
-  ELIXIR: "1.14.2"
+  ELIXIR: "1.14.3"
 
 jobs:
   build:


### PR DESCRIPTION
OTP Changelog:
https://github.com/erlang/otp/releases/tag/OTP-25.2.1

Elixir Changelog:
https://github.com/elixir-lang/elixir/releases/tag/v1.14.3