### PR TITLE
Use buildkit 0.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          # We are overriding the default buildkit version being used by Buildx. We need buildkit >= 12.0 and currently BuildX
+          # supports v0.11.6 https://github.com/docker/buildx/blob/b8739d74417f86aa8fc9aafb830a8ba656bdef0e/Dockerfile#L9.
+          # We should for any updates on buildx and on the setup-buildx-action itself.
+          driver-opts: |
+            image=moby/buildkit:v0.12.0
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
To correctly support registry build caches with GCR, we need to use buildkit 0.12 which we for now have to manually specify. See https://github.com/moby/buildkit/issues/2251.